### PR TITLE
Add SET_POINT_TEMPERATURE as identifier

### DIFF
--- a/h2-highchart/H2-HighChart.js
+++ b/h2-highchart/H2-HighChart.js
@@ -296,6 +296,7 @@ function defaultAttrib(DP, colorNr, idx) {
         break;
     case "SET_TEMPERATURE":
     case "SETPOINT":
+    case "SET_POINT_TEMPERATURE":
         attr.yaxis = 'Y1';
         attr.line  = 'L2';
         break;


### PR DESCRIPTION
Add SET_POINT_TEMPERATURE as identifier for Homematic IP devices like HmIP-WTH-2 or HmIP-eTRV-2 to the H2-HighChart.js configuration.